### PR TITLE
fix: remove GitHub Pages deployment from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           echo "Provider release created. Manual steps required for Terraform Registry publishing."
 
-  publish-docs:
-    name: Publish Documentation
+  generate-docs:
+    name: Generate Documentation
     runs-on: ubuntu-latest
     needs: release
     steps:
@@ -77,14 +77,11 @@ jobs:
       - name: Generate documentation
         run: tfplugindocs generate
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Verify documentation
+        run: |
+          if [ ! -d "docs" ]; then
+            echo "Documentation directory not found"
+            exit 1
+          fi
+          echo "Documentation generated successfully"
+          ls -la docs/


### PR DESCRIPTION
## Summary
- Removed GitHub Pages deployment steps from the release workflow
- Kept documentation generation for verification purposes
- Renamed job from `publish-docs` to `generate-docs` to better reflect its purpose

## Problem
The release workflow was failing with the error:
```
Error: Get Pages site failed. Please verify that the repository has Pages enabled
```

This occurred because the workflow was trying to deploy to GitHub Pages, but Pages is not enabled for this repository.

## Solution
- Removed `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` steps
- Kept the documentation generation step to ensure docs are still built and validated
- Added a verification step to confirm documentation is generated successfully

## Test Plan
- [x] Workflow syntax is valid
- [ ] Next release will trigger the updated workflow
- [ ] Documentation generation continues to work