### PR TITLE
fix: correct status page documentation to match actual implementation

### DIFF
--- a/docs/data-sources/status_page.md
+++ b/docs/data-sources/status_page.md
@@ -19,16 +19,28 @@ data "uptime_status_page" "example" {
 }
 
 # Use the status page data
+output "status_page_name" {
+  value = data.uptime_status_page.example.name
+}
+
 output "status_page_url" {
+  value = data.uptime_status_page.example.url
+}
+
+output "status_page_custom_domain" {
   value = data.uptime_status_page.example.custom_domain
 }
 
 output "status_page_monitors" {
-  value = data.uptime_status_page.example.monitor_ids
+  value = data.uptime_status_page.example.monitors
 }
 
-output "company_name" {
-  value = data.uptime_status_page.example.company_name
+output "status_page_period" {
+  value = data.uptime_status_page.example.period
+}
+
+output "show_incident_reasons" {
+  value = data.uptime_status_page.example.show_incident_reasons
 }
 ```
 

--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -15,38 +15,37 @@ Status page resource for displaying monitor statuses publicly
 ```terraform
 # Basic status page example
 resource "uptime_status_page" "public_status" {
-  name             = "Public Status Page"
-  custom_domain    = "status.example.com"
-  company_name     = "Example Corp"
-  company_url      = "https://example.com"
-  contact_email    = "support@example.com"
-  company_logo_url = "https://example.com/logo.png"
-  timezone         = "America/New_York"
+  name = "Public Status Page"
   
-  # Link monitors to display on the status page
-  monitor_ids = [
+  # Link monitors to display on the status page (required, 1-20 monitors)
+  monitors = [
     uptime_monitor.api_monitor.id,
     uptime_monitor.website_monitor.id
   ]
+  
+  # Optional: Time period for uptime statistics (defaults to 7 days)
+  period = 30  # Can be 7, 30, or 90 days
 }
 
-# Status page with custom branding
+# Status page with custom domain and authentication
 resource "uptime_status_page" "branded_status" {
-  name               = "Customer Portal Status"
-  custom_domain      = "status.myapp.com"
-  company_name       = "MyApp Inc"
-  company_url        = "https://myapp.com"
-  contact_email      = "ops@myapp.com"
-  company_logo_url   = "https://cdn.myapp.com/assets/logo.svg"
-  timezone           = "UTC"
-  hide_powered_by    = true
-  allow_search_index = false
+  name          = "Customer Portal Status"
+  custom_domain = "status.myapp.com"
   
-  monitor_ids = [
+  monitors = [
     uptime_monitor.frontend.id,
     uptime_monitor.backend.id,
     uptime_monitor.database.id
   ]
+  
+  # Optional: Show incident reasons publicly
+  show_incident_reasons = true
+  
+  # Optional: Protect with basic authentication
+  basic_auth = "admin:SecurePassword123"  # username:password format
+  
+  # Optional: Use 90-day uptime period
+  period = 90
 }
 
 # Example monitors to link to status page

--- a/examples/data-sources/uptime_status_page/data-source.tf
+++ b/examples/data-sources/uptime_status_page/data-source.tf
@@ -4,14 +4,26 @@ data "uptime_status_page" "example" {
 }
 
 # Use the status page data
+output "status_page_name" {
+  value = data.uptime_status_page.example.name
+}
+
 output "status_page_url" {
+  value = data.uptime_status_page.example.url
+}
+
+output "status_page_custom_domain" {
   value = data.uptime_status_page.example.custom_domain
 }
 
 output "status_page_monitors" {
-  value = data.uptime_status_page.example.monitor_ids
+  value = data.uptime_status_page.example.monitors
 }
 
-output "company_name" {
-  value = data.uptime_status_page.example.company_name
+output "status_page_period" {
+  value = data.uptime_status_page.example.period
+}
+
+output "show_incident_reasons" {
+  value = data.uptime_status_page.example.show_incident_reasons
 }

--- a/examples/resources/uptime_status_page/resource.tf
+++ b/examples/resources/uptime_status_page/resource.tf
@@ -1,37 +1,36 @@
 # Basic status page example
 resource "uptime_status_page" "public_status" {
-  name             = "Public Status Page"
-  custom_domain    = "status.example.com"
-  company_name     = "Example Corp"
-  company_url      = "https://example.com"
-  contact_email    = "support@example.com"
-  company_logo_url = "https://example.com/logo.png"
-  timezone         = "America/New_York"
+  name = "Public Status Page"
   
-  # Link monitors to display on the status page
-  monitor_ids = [
+  # Link monitors to display on the status page (required, 1-20 monitors)
+  monitors = [
     uptime_monitor.api_monitor.id,
     uptime_monitor.website_monitor.id
   ]
+  
+  # Optional: Time period for uptime statistics (defaults to 7 days)
+  period = 30  # Can be 7, 30, or 90 days
 }
 
-# Status page with custom branding
+# Status page with custom domain and authentication
 resource "uptime_status_page" "branded_status" {
-  name               = "Customer Portal Status"
-  custom_domain      = "status.myapp.com"
-  company_name       = "MyApp Inc"
-  company_url        = "https://myapp.com"
-  contact_email      = "ops@myapp.com"
-  company_logo_url   = "https://cdn.myapp.com/assets/logo.svg"
-  timezone           = "UTC"
-  hide_powered_by    = true
-  allow_search_index = false
+  name          = "Customer Portal Status"
+  custom_domain = "status.myapp.com"
   
-  monitor_ids = [
+  monitors = [
     uptime_monitor.frontend.id,
     uptime_monitor.backend.id,
     uptime_monitor.database.id
   ]
+  
+  # Optional: Show incident reasons publicly
+  show_incident_reasons = true
+  
+  # Optional: Protect with basic authentication
+  basic_auth = "admin:SecurePassword123"  # username:password format
+  
+  # Optional: Use 90-day uptime period
+  period = 90
 }
 
 # Example monitors to link to status page


### PR DESCRIPTION
## Summary
Fixed incorrect status page documentation that was showing non-existent attributes in examples.

## Problem
The Terraform Registry documentation for the `uptime_status_page` resource was showing examples with attributes that don't exist in the actual implementation, such as:
- `company_name`, `company_url`, `contact_email`, `company_logo_url`
- `timezone`, `hide_powered_by`, `allow_search_index`
- Using `monitor_ids` instead of `monitors`

## Solution
Updated the documentation to match the actual schema from the Go implementation:

### Correct Attributes
**Required:**
- `name` - Display name for the status page
- `monitors` - List of monitor IDs (1-20 monitors)

**Optional:**
- `period` - Time period for uptime statistics (7, 30, or 90 days)
- `custom_domain` - Custom domain for the status page
- `show_incident_reasons` - Whether to show incident reasons publicly
- `basic_auth` - Basic authentication in 'username:password' format

**Read-only:**
- `id` - Unique identifier
- `created_at` - Unix timestamp
- `url` - The URL where the status page can be accessed

## Changes
- Fixed resource examples to use correct attribute names
- Fixed data source examples to reference correct attributes
- Removed all non-existent attributes from examples
- Added comments explaining optional attributes and their constraints

## Test Plan
- [x] Documentation regenerated with `tfplugindocs`
- [x] Examples match the actual resource schema in `internal/resources/status_page_resource.go`
- [x] Data source examples match the schema in `internal/datasources/status_page_data_source.go`