### PR TITLE
fix: update API base URL and correct example syntax

### DIFF
--- a/docs/data-sources/status_page.md
+++ b/docs/data-sources/status_page.md
@@ -19,16 +19,28 @@ data "uptime_status_page" "example" {
 }
 
 # Use the status page data
+output "status_page_name" {
+  value = data.uptime_status_page.example.name
+}
+
 output "status_page_url" {
+  value = data.uptime_status_page.example.url
+}
+
+output "status_page_custom_domain" {
   value = data.uptime_status_page.example.custom_domain
 }
 
 output "status_page_monitors" {
-  value = data.uptime_status_page.example.monitor_ids
+  value = data.uptime_status_page.example.monitors
 }
 
-output "company_name" {
-  value = data.uptime_status_page.example.company_name
+output "status_page_period" {
+  value = data.uptime_status_page.example.period
+}
+
+output "show_incident_reasons" {
+  value = data.uptime_status_page.example.show_incident_reasons
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,13 +24,13 @@ provider "uptime" {
   # Configuration options
   # api_key and base_url can be set via environment variables:
   # export UPTIME_API_KEY="your-api-key"
-  # export UPTIME_BASE_URL="https://api.uptime-monitor.io" (optional)
+  # export UPTIME_BASE_URL="https://uptime-monitor.io" (optional)
 }
 
 # Or configure explicitly
 provider "uptime" {
   api_key  = "your-api-key"
-  base_url = "https://api.uptime-monitor.io" # Optional, defaults to production API
+  base_url = "https://uptime-monitor.io" # Optional, defaults to production API
 }
 ```
 

--- a/docs/resources/contact.md
+++ b/docs/resources/contact.md
@@ -18,7 +18,7 @@ resource "uptime_contact" "email_contact" {
   name    = "DevOps Team Email"
   channel = "email"
 
-  email_settings {
+  email_settings = {
     email = "devops@example.com"
   }
 }
@@ -29,7 +29,7 @@ resource "uptime_contact" "sms_contact" {
   channel          = "sms"
   down_alerts_only = true
 
-  sms_settings {
+  sms_settings = {
     phone = "+1234567890"
   }
 }
@@ -39,7 +39,7 @@ resource "uptime_contact" "slack_contact" {
   name    = "Slack Alerts"
   channel = "slack"
 
-  slack_settings {
+  slack_settings = {
     webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
   }
 }
@@ -49,7 +49,7 @@ resource "uptime_contact" "discord_contact" {
   name    = "Discord Notifications"
   channel = "discord"
 
-  discord_settings {
+  discord_settings = {
     webhook_url = "https://discord.com/api/webhooks/000000000000000000/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }
@@ -59,11 +59,11 @@ resource "uptime_contact" "pagerduty_contact" {
   name    = "PagerDuty Integration"
   channel = "pagerduty"
 
-  pagerduty_settings {
+  pagerduty_settings = {
     integration_key        = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     auto_resolve_incidents = true
 
-    severity_mapping {
+    severity_mapping = {
       critical = "critical"
       high     = "error"
       medium   = "warning"
@@ -77,22 +77,23 @@ resource "uptime_contact" "opsgenie_contact" {
   name    = "Opsgenie Alerts"
   channel = "opsgenie"
 
-  opsgenie_settings {
+  opsgenie_settings = {
     api_key           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     eu_instance       = false
     auto_close_alerts = true
     priority          = "P2"
     tags              = ["uptime-monitor", "production"]
 
-    responders {
-      type = "team"
-      name = "DevOps Team"
-    }
-
-    responders {
-      type     = "user"
-      username = "john.doe@example.com"
-    }
+    responders = [
+      {
+        type = "team"
+        name = "DevOps Team"
+      },
+      {
+        type     = "user"
+        username = "john.doe@example.com"
+      }
+    ]
   }
 }
 
@@ -101,7 +102,7 @@ resource "uptime_contact" "webhook_contact" {
   name    = "Custom Webhook"
   channel = "webhook"
 
-  webhook_settings {
+  webhook_settings = {
     url = "https://api.example.com/webhooks/monitoring"
   }
 }
@@ -111,7 +112,7 @@ resource "uptime_contact" "incidentio_contact" {
   name    = "Incident.io"
   channel = "incidentio"
 
-  incidentio_settings {
+  incidentio_settings = {
     webhook_url            = "https://api.incident.io/v1/webhooks/xxxxxxxx"
     bearer_token           = "inc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     auto_resolve_incidents = true
@@ -123,7 +124,7 @@ resource "uptime_contact" "zendesk_contact" {
   name    = "Zendesk Support"
   channel = "zendesk"
 
-  zendesk_settings {
+  zendesk_settings = {
     subdomain          = "mycompany"
     email              = "support@mycompany.com"
     api_token          = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -131,10 +132,12 @@ resource "uptime_contact" "zendesk_contact" {
     auto_solve_tickets = true
     tags               = ["monitoring", "automated"]
 
-    custom_fields {
-      id    = 360000000000
-      value = "production"
-    }
+    custom_fields = [
+      {
+        id    = 360000000000
+        value = "production"
+      }
+    ]
   }
 }
 ```

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -19,13 +19,25 @@ resource "uptime_monitor" "example" {
   type           = "https"
   check_interval = 60
   timeout        = 30
+  fail_threshold = 2
   regions        = ["us-east-1", "eu-west-1"]
+  contacts       = [uptime_contact.main.id]
   
   https_settings = {
-    method                       = "get"
+    method                       = "GET"
     expected_status_codes        = "200"
     check_certificate_expiration = true
     follow_redirects             = true
+  }
+}
+
+# Example contact for monitor notifications
+resource "uptime_contact" "main" {
+  name    = "DevOps Team"
+  channel = "email"
+
+  email_settings = {
+    email = "devops@example.com"
   }
 }
 ```

--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -15,38 +15,37 @@ Status page resource for displaying monitor statuses publicly
 ```terraform
 # Basic status page example
 resource "uptime_status_page" "public_status" {
-  name             = "Public Status Page"
-  custom_domain    = "status.example.com"
-  company_name     = "Example Corp"
-  company_url      = "https://example.com"
-  contact_email    = "support@example.com"
-  company_logo_url = "https://example.com/logo.png"
-  timezone         = "America/New_York"
+  name = "Public Status Page"
   
-  # Link monitors to display on the status page
-  monitor_ids = [
+  # Link monitors to display on the status page (required, 1-20 monitors)
+  monitors = [
     uptime_monitor.api_monitor.id,
     uptime_monitor.website_monitor.id
   ]
+  
+  # Optional: Time period for uptime statistics (defaults to 7 days)
+  period = 30  # Can be 7, 30, or 90 days
 }
 
-# Status page with custom branding
+# Status page with custom domain and authentication
 resource "uptime_status_page" "branded_status" {
-  name               = "Customer Portal Status"
-  custom_domain      = "status.myapp.com"
-  company_name       = "MyApp Inc"
-  company_url        = "https://myapp.com"
-  contact_email      = "ops@myapp.com"
-  company_logo_url   = "https://cdn.myapp.com/assets/logo.svg"
-  timezone           = "UTC"
-  hide_powered_by    = true
-  allow_search_index = false
+  name          = "Customer Portal Status"
+  custom_domain = "status.myapp.com"
   
-  monitor_ids = [
+  monitors = [
     uptime_monitor.frontend.id,
     uptime_monitor.backend.id,
     uptime_monitor.database.id
   ]
+  
+  # Optional: Show incident reasons publicly
+  show_incident_reasons = true
+  
+  # Optional: Protect with basic authentication
+  basic_auth = "admin:SecurePassword123"  # username:password format
+  
+  # Optional: Use 90-day uptime period
+  period = 90
 }
 
 # Example monitors to link to status page

--- a/examples/data-sources/uptime_status_page/data-source.tf
+++ b/examples/data-sources/uptime_status_page/data-source.tf
@@ -4,14 +4,26 @@ data "uptime_status_page" "example" {
 }
 
 # Use the status page data
+output "status_page_name" {
+  value = data.uptime_status_page.example.name
+}
+
 output "status_page_url" {
+  value = data.uptime_status_page.example.url
+}
+
+output "status_page_custom_domain" {
   value = data.uptime_status_page.example.custom_domain
 }
 
 output "status_page_monitors" {
-  value = data.uptime_status_page.example.monitor_ids
+  value = data.uptime_status_page.example.monitors
 }
 
-output "company_name" {
-  value = data.uptime_status_page.example.company_name
+output "status_page_period" {
+  value = data.uptime_status_page.example.period
+}
+
+output "show_incident_reasons" {
+  value = data.uptime_status_page.example.show_incident_reasons
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,11 +11,11 @@ provider "uptime" {
   # Configuration options
   # api_key and base_url can be set via environment variables:
   # export UPTIME_API_KEY="your-api-key"
-  # export UPTIME_BASE_URL="https://api.uptime-monitor.io" (optional)
+  # export UPTIME_BASE_URL="https://uptime-monitor.io" (optional)
 }
 
 # Or configure explicitly
 provider "uptime" {
   api_key  = "your-api-key"
-  base_url = "https://api.uptime-monitor.io" # Optional, defaults to production API
+  base_url = "https://uptime-monitor.io" # Optional, defaults to production API
 }

--- a/examples/resources/uptime_contact/resource.tf
+++ b/examples/resources/uptime_contact/resource.tf
@@ -3,7 +3,7 @@ resource "uptime_contact" "email_contact" {
   name    = "DevOps Team Email"
   channel = "email"
 
-  email_settings {
+  email_settings = {
     email = "devops@example.com"
   }
 }
@@ -14,7 +14,7 @@ resource "uptime_contact" "sms_contact" {
   channel          = "sms"
   down_alerts_only = true
 
-  sms_settings {
+  sms_settings = {
     phone = "+1234567890"
   }
 }
@@ -24,7 +24,7 @@ resource "uptime_contact" "slack_contact" {
   name    = "Slack Alerts"
   channel = "slack"
 
-  slack_settings {
+  slack_settings = {
     webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
   }
 }
@@ -34,7 +34,7 @@ resource "uptime_contact" "discord_contact" {
   name    = "Discord Notifications"
   channel = "discord"
 
-  discord_settings {
+  discord_settings = {
     webhook_url = "https://discord.com/api/webhooks/000000000000000000/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }
@@ -44,11 +44,11 @@ resource "uptime_contact" "pagerduty_contact" {
   name    = "PagerDuty Integration"
   channel = "pagerduty"
 
-  pagerduty_settings {
+  pagerduty_settings = {
     integration_key        = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     auto_resolve_incidents = true
 
-    severity_mapping {
+    severity_mapping = {
       critical = "critical"
       high     = "error"
       medium   = "warning"
@@ -62,22 +62,23 @@ resource "uptime_contact" "opsgenie_contact" {
   name    = "Opsgenie Alerts"
   channel = "opsgenie"
 
-  opsgenie_settings {
+  opsgenie_settings = {
     api_key           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     eu_instance       = false
     auto_close_alerts = true
     priority          = "P2"
     tags              = ["uptime-monitor", "production"]
 
-    responders {
-      type = "team"
-      name = "DevOps Team"
-    }
-
-    responders {
-      type     = "user"
-      username = "john.doe@example.com"
-    }
+    responders = [
+      {
+        type = "team"
+        name = "DevOps Team"
+      },
+      {
+        type     = "user"
+        username = "john.doe@example.com"
+      }
+    ]
   }
 }
 
@@ -86,7 +87,7 @@ resource "uptime_contact" "webhook_contact" {
   name    = "Custom Webhook"
   channel = "webhook"
 
-  webhook_settings {
+  webhook_settings = {
     url = "https://api.example.com/webhooks/monitoring"
   }
 }
@@ -96,7 +97,7 @@ resource "uptime_contact" "incidentio_contact" {
   name    = "Incident.io"
   channel = "incidentio"
 
-  incidentio_settings {
+  incidentio_settings = {
     webhook_url            = "https://api.incident.io/v1/webhooks/xxxxxxxx"
     bearer_token           = "inc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     auto_resolve_incidents = true
@@ -108,7 +109,7 @@ resource "uptime_contact" "zendesk_contact" {
   name    = "Zendesk Support"
   channel = "zendesk"
 
-  zendesk_settings {
+  zendesk_settings = {
     subdomain          = "mycompany"
     email              = "support@mycompany.com"
     api_token          = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -116,9 +117,11 @@ resource "uptime_contact" "zendesk_contact" {
     auto_solve_tickets = true
     tags               = ["monitoring", "automated"]
 
-    custom_fields {
-      id    = 360000000000
-      value = "production"
-    }
+    custom_fields = [
+      {
+        id    = 360000000000
+        value = "production"
+      }
+    ]
   }
 }

--- a/examples/resources/uptime_monitor/resource.tf
+++ b/examples/resources/uptime_monitor/resource.tf
@@ -4,12 +4,24 @@ resource "uptime_monitor" "example" {
   type           = "https"
   check_interval = 60
   timeout        = 30
+  fail_threshold = 2
   regions        = ["us-east-1", "eu-west-1"]
+  contacts       = [uptime_contact.main.id]
   
   https_settings = {
-    method                       = "get"
+    method                       = "GET"
     expected_status_codes        = "200"
     check_certificate_expiration = true
     follow_redirects             = true
+  }
+}
+
+# Example contact for monitor notifications
+resource "uptime_contact" "main" {
+  name    = "DevOps Team"
+  channel = "email"
+
+  email_settings = {
+    email = "devops@example.com"
   }
 }

--- a/examples/resources/uptime_status_page/resource.tf
+++ b/examples/resources/uptime_status_page/resource.tf
@@ -1,37 +1,36 @@
 # Basic status page example
 resource "uptime_status_page" "public_status" {
-  name             = "Public Status Page"
-  custom_domain    = "status.example.com"
-  company_name     = "Example Corp"
-  company_url      = "https://example.com"
-  contact_email    = "support@example.com"
-  company_logo_url = "https://example.com/logo.png"
-  timezone         = "America/New_York"
+  name = "Public Status Page"
   
-  # Link monitors to display on the status page
-  monitor_ids = [
+  # Link monitors to display on the status page (required, 1-20 monitors)
+  monitors = [
     uptime_monitor.api_monitor.id,
     uptime_monitor.website_monitor.id
   ]
+  
+  # Optional: Time period for uptime statistics (defaults to 7 days)
+  period = 30  # Can be 7, 30, or 90 days
 }
 
-# Status page with custom branding
+# Status page with custom domain and authentication
 resource "uptime_status_page" "branded_status" {
-  name               = "Customer Portal Status"
-  custom_domain      = "status.myapp.com"
-  company_name       = "MyApp Inc"
-  company_url        = "https://myapp.com"
-  contact_email      = "ops@myapp.com"
-  company_logo_url   = "https://cdn.myapp.com/assets/logo.svg"
-  timezone           = "UTC"
-  hide_powered_by    = true
-  allow_search_index = false
+  name          = "Customer Portal Status"
+  custom_domain = "status.myapp.com"
   
-  monitor_ids = [
+  monitors = [
     uptime_monitor.frontend.id,
     uptime_monitor.backend.id,
     uptime_monitor.database.id
   ]
+  
+  # Optional: Show incident reasons publicly
+  show_incident_reasons = true
+  
+  # Optional: Protect with basic authentication
+  basic_auth = "admin:SecurePassword123"  # username:password format
+  
+  # Optional: Use 90-day uptime period
+  period = 90
 }
 
 # Example monitors to link to status page


### PR DESCRIPTION
## Summary
Updated all examples to use the correct API base URL and fixed syntax issues to match actual Terraform usage patterns.

## Changes

### API Base URL
- Changed from `https://api.uptime-monitor.io` to `https://uptime-monitor.io` 
- Updated in provider examples and documentation

### Syntax Corrections
Fixed all nested blocks to use assignment syntax (`=`) instead of block syntax:
- `email_settings = { ... }` instead of `email_settings { ... }`
- `https_settings = { ... }` instead of `https_settings { ... }`
- Applied to all nested settings blocks (sms_settings, slack_settings, discord_settings, etc.)

### Monitor Resource Improvements
- Added `fail_threshold` attribute to examples
- Added `contacts` attribute with proper reference to contact resources
- Changed HTTP method from lowercase "get" to uppercase "GET"
- Added contact resource example alongside monitor examples

### Complex Settings Fixes
- Fixed `opsgenie_settings.responders` to use array syntax `responders = [...]`
- Fixed `zendesk_settings.custom_fields` to use array syntax `custom_fields = [...]`

## Verification
The corrected syntax matches the working example provided:
```hcl
provider "uptime" {
  api_key  = var.api_key
  base_url = "https://uptime-monitor.io"
}

resource "uptime_contact" "main" {
  name    = "Pavel Lazureykis"
  channel = "email"

  email_settings = {
    email = "pavel@lazureykis.dev"
  }
}

resource "uptime_monitor" "example_com" {
  name           = "Example.com Monitor"
  url            = "https://google.com"
  type           = "https"
  check_interval = 30
  timeout        = 10
  fail_threshold = 2
  regions        = ["us-east-1", "eu-west-1"]
  contacts       = [uptime_contact.main.id]

  https_settings = {
    method                       = "GET"
    expected_status_codes        = "200"
    check_certificate_expiration = true
    follow_redirects             = true
  }
}
```

## Test Plan
- [x] Documentation regenerated with tfplugindocs
- [x] Examples follow correct Terraform HCL syntax
- [x] All nested blocks use assignment operator
- [x] Complex nested structures (arrays of objects) correctly formatted