### PR TITLE
fix: update documentation generation to use correct provider name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         run: go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
       
       - name: Generate documentation
-        run: tfplugindocs generate --provider-name uptime
+        run: tfplugindocs generate --provider-name uptime --rendered-provider-name "Uptime Monitor"
       
       - name: Check for uncommitted documentation changes
         run: |

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ validate-all: ## Run all validation checks including acceptance tests
 .PHONY: docs
 docs: ## Generate provider documentation
 	@if command -v tfplugindocs &> /dev/null; then \
-		tfplugindocs generate; \
+		tfplugindocs generate --provider-name uptime --rendered-provider-name "Uptime Monitor"; \
 		echo "${GREEN}✓${NC} Documentation generated"; \
 	else \
 		echo "${YELLOW}⚠${NC} tfplugindocs not installed. Install with:"; \
@@ -127,7 +127,7 @@ docs: ## Generate provider documentation
 .PHONY: docs-check
 docs-check: ## Check if documentation is up to date
 	@if command -v tfplugindocs &> /dev/null; then \
-		tfplugindocs generate; \
+		tfplugindocs generate --provider-name uptime --rendered-provider-name "Uptime Monitor"; \
 		if git diff --exit-code docs/; then \
 			echo "${GREEN}✓${NC} Documentation is up to date"; \
 		else \

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -111,11 +111,11 @@ fi
 # 8. Check documentation with tfplugindocs if available
 if command -v tfplugindocs &> /dev/null; then
     print_step "Checking provider documentation..."
-    tfplugindocs generate
+    tfplugindocs generate --provider-name uptime --rendered-provider-name "Uptime Monitor"
     if git diff --exit-code docs/; then
         print_success "Documentation is up to date"
     else
-        print_error "Documentation needs updating. Run 'tfplugindocs generate'"
+        print_error "Documentation needs updating. Run 'make docs'"
         git checkout -- docs/
         FAILED=1
     fi


### PR DESCRIPTION
## Summary
Fixes the CI documentation check failure by ensuring tfplugindocs generates documentation with the correct provider name.

## Problem
The CI pipeline was failing with the following error:
```
Documentation is out of date. Please run 'tfplugindocs generate' and commit the changes.
```

The issue was that tfplugindocs was generating documentation with:
- `page_title: "uptime"` 
- `# uptime Provider`

But the committed documentation has:
- `page_title: "Uptime Monitor"`
- `# Uptime Monitor Provider`

## Solution
Added the `--rendered-provider-name "Uptime Monitor"` parameter to all tfplugindocs commands:
- GitHub Actions CI workflow (`documentation` job)
- Makefile (`docs` and `docs-check` targets)
- Validation script (`scripts/validate.sh`)

## Test Plan
- [x] Ran `make docs` locally - no documentation changes generated
- [x] Ran `make docs-check` locally - passes without errors
- [ ] CI pipeline should now pass the documentation check

## Related Issues
This was causing the Documentation check to fail in PR #16 and other recent PRs.